### PR TITLE
Add PHP and Symfony tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,19 @@
 version: 2.1
 orbs:
-  node: circleci/node@1.1.6
+  docker: circleci/docker@1.5.0
 jobs:
   build-and-test:
     executor:
-      name: node/default
+      name: docker/docker
     steps:
+      - setup_remote_docker:
+          version: 19.03.13
       - checkout
-      - node/with-cache:
-          steps:
-            - run: npm install yarn
-            - run: yarn install
-            - run: npm test
+      - run: docker-compose build
+      - run: docker-compose up -d app database assets
+      - run: docker exec -t project_app_1 bin/scripts/wait-for-app.sh
+      - run: docker exec -t project_assets_1 yarn run test
+      - run: docker exec -t project_app_1 php bin/phpunit
 workflows:
     build-and-test:
       jobs:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,13 +8,11 @@ blocks:
   - name: No Agenda
     task:
       jobs:
-        - name: JavaScript Unit Tests
+        - name: Unit Tests
           commands:
             - checkout
-            - sem-version node 12
-            - cache restore
-            - npm install yarn
-            - yarn install
-            - cache store
-            - yarn build --if-present
-            - yarn test
+            - docker-compose build
+            - docker-compose up -d app database assets
+            - docker exec -t noagenda_app_1 bin/scripts/wait-for-app.sh
+            - docker exec -t noagenda_assets_1 yarn run test
+            - docker exec -t noagenda_app_1 php bin/phpunit

--- a/bin/scripts/wait-for-app.sh
+++ b/bin/scripts/wait-for-app.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+echo "Waiting for app to be ready..."
+
+until nc -z "app" "9000"; do
+  sleep 1
+done
+
+echo "App ready"
+
+exit 0


### PR DESCRIPTION
Adds some basic tests for PHP classes, fixes #7.

Currently working on getting Symfony testing working, but since that has to be done through Docker, I want to take a look at improving the Docker setup first.