### PR TITLE
fix old-style string interpretation

### DIFF
--- a/src/Crawling/EpisodeCoverCrawler.php
+++ b/src/Crawling/EpisodeCoverCrawler.php
@@ -54,8 +54,8 @@ class EpisodeCoverCrawler implements EpisodeFileCrawlerInterface
         $filters = array_keys($this->filterManager->getFilterConfiguration()->all());
 
         foreach ($filters as $filter) {
-            $this->filterService->bustCache("${code}.png", $filter);
-            $this->filterService->getUrlOfFilteredImage("${code}.png", $filter);
+            $this->filterService->bustCache("{$code}.png", $filter);
+            $this->filterService->getUrlOfFilteredImage("{$code}.png", $filter);
         }
     }
 }


### PR DESCRIPTION
fixes Deprecated: Using ${var} in strings is deprecated, use {$var} instead
