### PR TITLE
Keep crawler scheduler running

### DIFF
--- a/compose.services.yaml
+++ b/compose.services.yaml
@@ -4,7 +4,7 @@ services:
     restart: unless-stopped
     tty: true
     entrypoint: app-php-entrypoint
-    command: bin/console messenger:consume --sleep 30 --time-limit 3600 scheduler_crawler crawler async
+    command: bin/console messenger:consume --sleep 30 scheduler_crawler crawler async
     depends_on:
       - app
     volumes:


### PR DESCRIPTION
## Summary
Remove the one-hour Messenger worker time limit from the Compose worker configuration.

## Why
The cold RSS crawl is scheduled hourly. Exiting the worker at the same boundary can prevent that crawl from running after scheduler state is reset.

## Testing
- `podman compose -f compose.yaml -f compose.services.yaml config`
- `git diff --check`