### PR TITLE
Attach RSS album art to Mastodon posts

### DIFF
--- a/src/Crawling/LiveItemProcessor.php
+++ b/src/Crawling/LiveItemProcessor.php
@@ -29,6 +29,7 @@ class LiveItemProcessor
         $document->loadXML($feed);
 
         $xpath = new \DOMXPath($document);
+        $xpath->registerNamespace('itunes', 'http://www.itunes.com/dtds/podcast-1.0.dtd');
         $xpath->registerNamespace('podcast', 'https://podcastindex.org/namespace/1.0');
 
         foreach ($xpath->query('/rss/channel/podcast:liveItem[@status="live"]') as $liveItem) {
@@ -36,6 +37,7 @@ class LiveItemProcessor
             $title = trim($xpath->evaluate('string(title)', $liveItem));
             $uri = trim($xpath->evaluate('string(link)', $liveItem))
                 ?: trim($xpath->evaluate('string(podcast:contentLink/@href)', $liveItem));
+            $imageUri = trim($xpath->evaluate('string(itunes:image/@href)', $liveItem));
             $start = $liveItem->getAttribute('start');
 
             if (!$guid || !$title || !$uri || !$start) {
@@ -58,7 +60,7 @@ class LiveItemProcessor
 
             $this->logger->info(sprintf('Found live item "%s".', $guid));
 
-            $this->notificationPublisher->publishMastodonLiveAnnouncement($title, $uri);
+            $this->notificationPublisher->publishMastodonLiveAnnouncement($title, $uri, $imageUri ?: null);
             $this->notificationPublisher->sendUserLiveNotifications($title, $uri);
             $this->entityManager->persist($signal);
 

--- a/src/Crawling/NotificationPublisher.php
+++ b/src/Crawling/NotificationPublisher.php
@@ -11,6 +11,8 @@ use Minishlink\WebPush\WebPush;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use Sentry\Severity;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Component\Mime\Part\Multipart\FormDataPart;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -23,6 +25,7 @@ class NotificationPublisher
 
     public function __construct(
         private readonly NotificationSubscriptionRepository $notificationSubscriptionRepository,
+        private readonly HttpClientInterface $httpClient,
         private readonly HttpClientInterface $mastodonClient,
         private readonly HttpClientInterface $secondaryMastodonClient,
         private readonly RouterInterface $router,
@@ -88,21 +91,23 @@ class NotificationPublisher
         $title = sprintf('No Agenda Episode %s - %s', $code, $episode->getName());
         $uri = $this->router->generate('podcast_episode', ['code' => $code], RouterInterface::ABSOLUTE_URL);
 
-        $this->publishMastodonStatus("$title $uri", sprintf('episode %s', $code));
+        $this->publishMastodonStatus("$title $uri", sprintf('episode %s', $code), $episode->getCoverUri(), $title);
     }
 
-    public function publishMastodonLiveAnnouncement(string $title, string $uri): void
+    public function publishMastodonLiveAnnouncement(string $title, string $uri, ?string $imageUri): void
     {
-        $this->publishMastodonStatus("$title $uri", 'live item');
+        $this->publishMastodonStatus("$title $uri", 'live item', $imageUri, $title);
     }
 
-    private function publishMastodonStatus(string $status, string $description): void
+    private function publishMastodonStatus(string $status, string $description, ?string $imageUri, string $imageDescription): void
     {
         if (!$this->mastodonPublish) {
             $this->logger->info('Publishing to Mastodon has been disabled');
 
             return;
         }
+
+        $image = $imageUri ? $this->downloadImage($imageUri) : null;
 
         $accounts = [
             'primary' => [$this->mastodonClient, $this->mastodonAccessToken],
@@ -119,8 +124,15 @@ class NotificationPublisher
             $this->logger->debug(sprintf('Publishing Mastodon post for %s to %s account', $description, $account));
 
             try {
+                $mediaId = $image ? $this->uploadMastodonImage($client, $image, $imageDescription, $account) : null;
+                $body = ['status' => $status];
+
+                if ($mediaId) {
+                    $body['media_ids'] = [$mediaId];
+                }
+
                 $response = $client->request('POST', 'statuses', [
-                    'body' => http_build_query(['status' => $status]),
+                    'body' => http_build_query($body),
                 ]);
 
                 if (200 !== $statusCode = $response->getStatusCode()) {
@@ -137,6 +149,66 @@ class NotificationPublisher
 
                 captureException($exception);
             }
+        }
+    }
+
+    private function downloadImage(string $uri): ?array
+    {
+        try {
+            $response = $this->httpClient->request('GET', $uri);
+
+            if (200 !== $statusCode = $response->getStatusCode()) {
+                $this->logger->warning(sprintf('Failed to download Mastodon image: Response code %s', $statusCode));
+
+                return null;
+            }
+
+            $contentType = strtok($response->getHeaders()['content-type'][0] ?? 'image/jpeg', ';');
+
+            if (!str_starts_with($contentType, 'image/')) {
+                $this->logger->warning(sprintf('Mastodon image has invalid content type "%s"', $contentType));
+
+                return null;
+            }
+
+            $filename = basename(parse_url($uri, PHP_URL_PATH)) ?: 'album-art.jpg';
+
+            return [$response->getContent(), $filename, $contentType];
+        } catch (\Throwable $exception) {
+            $this->logger->warning(sprintf('Failed to download Mastodon image: %s', $exception->getMessage()));
+
+            captureException($exception);
+
+            return null;
+        }
+    }
+
+    private function uploadMastodonImage(HttpClientInterface $client, array $image, string $description, string $account): ?string
+    {
+        try {
+            [$content, $filename, $contentType] = $image;
+            $formData = new FormDataPart([
+                'file' => new DataPart($content, $filename, $contentType),
+                'description' => $description,
+            ]);
+            $response = $client->request('POST', 'media', [
+                'headers' => $formData->getPreparedHeaders()->toArray(),
+                'body' => $formData->bodyToIterable(),
+            ]);
+
+            if (200 !== $statusCode = $response->getStatusCode()) {
+                $this->logger->warning(sprintf('Failed to upload image to %s Mastodon account: Response code %s; publishing without image', $account, $statusCode));
+
+                return null;
+            }
+
+            return json_decode($response->getContent(), true)['id'] ?? null;
+        } catch (\Throwable $exception) {
+            $this->logger->warning(sprintf('Failed to upload image to %s Mastodon account: %s; publishing without image', $account, $exception->getMessage()));
+
+            captureException($exception);
+
+            return null;
         }
     }
 

--- a/tests/Crawling/LiveItemProcessorTest.php
+++ b/tests/Crawling/LiveItemProcessorTest.php
@@ -22,7 +22,7 @@ class LiveItemProcessorTest extends TestCase
 
         $repository->expects($this->once())->method('exists')->willReturn(false);
         $publisher->expects($this->once())->method('publishMastodonLiveAnnouncement')
-            ->with('No Agenda Episode 1889 Live', 'https://example.com/live');
+            ->with('No Agenda Episode 1889 Live', 'https://example.com/live', 'https://example.com/1889.jpg');
         $publisher->expects($this->once())->method('sendUserLiveNotifications')
             ->with('No Agenda Episode 1889 Live', 'https://example.com/live');
         $entityManager->expects($this->once())->method('persist')
@@ -52,11 +52,13 @@ class LiveItemProcessorTest extends TestCase
     private function feed(string $status): string
     {
         return <<<XML
-            <rss xmlns:podcast="https://podcastindex.org/namespace/1.0">
+            <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+                 xmlns:podcast="https://podcastindex.org/namespace/1.0">
               <channel>
                 <podcast:liveItem status="$status" start="2026-07-26T17:55:00+00:00">
                   <title>No Agenda Episode 1889 Live</title>
                   <guid>show-1889</guid>
+                  <itunes:image href="https://example.com/1889.jpg" />
                   <podcast:contentLink href="https://example.com/live">Listen live</podcast:contentLink>
                 </podcast:liveItem>
               </channel>

--- a/tests/Crawling/NotificationPublisherTest.php
+++ b/tests/Crawling/NotificationPublisherTest.php
@@ -12,17 +12,61 @@ use Symfony\Component\Routing\RouterInterface;
 
 class NotificationPublisherTest extends TestCase
 {
-    public function testPublishesLiveAnnouncementToBothMastodonAccounts(): void
+    public function testPublishesLiveAnnouncementWithImageToBothMastodonAccounts(): void
     {
         $requests = [];
-        $responseFactory = function (string $method, string $url, array $options) use (&$requests): MockResponse {
+        $publisher = $this->createPublisher($requests);
+
+        $publisher->publishMastodonLiveAnnouncement(
+            'No Agenda 1889 Live',
+            'https://example.com/live',
+            'https://example.com/1889.jpg',
+        );
+
+        $this->assertSame([
+            ['POST', 'https://primary.example/api/v1/media'],
+            ['POST', 'https://primary.example/api/v1/statuses', 'status=No+Agenda+1889+Live+https%3A%2F%2Fexample.com%2Flive&media_ids%5B0%5D=primary-media'],
+            ['POST', 'https://secondary.example/api/v1/media'],
+            ['POST', 'https://secondary.example/api/v1/statuses', 'status=No+Agenda+1889+Live+https%3A%2F%2Fexample.com%2Flive&media_ids%5B0%5D=secondary-media'],
+        ], $requests);
+    }
+
+    public function testPublishesWithoutImageWhenUploadFails(): void
+    {
+        $requests = [];
+        $publisher = $this->createPublisher($requests, 403);
+
+        $publisher->publishMastodonLiveAnnouncement(
+            'No Agenda 1889 Live',
+            'https://example.com/live',
+            'https://example.com/1889.jpg',
+        );
+
+        $this->assertSame(
+            ['POST', 'https://primary.example/api/v1/statuses', 'status=No+Agenda+1889+Live+https%3A%2F%2Fexample.com%2Flive'],
+            $requests[1],
+        );
+    }
+
+    private function createPublisher(array &$requests, int $primaryMediaStatus = 200): NotificationPublisher
+    {
+        $responseFactory = function (string $method, string $url, array $options) use (&$requests, $primaryMediaStatus): MockResponse {
+            if (str_ends_with($url, '/media')) {
+                $requests[] = [$method, $url];
+                $status = str_contains($url, 'primary.example') ? $primaryMediaStatus : 200;
+                $id = str_contains($url, 'primary.example') ? 'primary-media' : 'secondary-media';
+
+                return new MockResponse(json_encode(['id' => $id]), ['http_code' => $status]);
+            }
+
             $requests[] = [$method, $url, $options['body']];
 
             return new MockResponse('{}', ['http_code' => 200]);
         };
 
-        $publisher = new NotificationPublisher(
+        return new NotificationPublisher(
             $this->getMockBuilder(NotificationSubscriptionRepository::class)->disableOriginalConstructor()->getMock(),
+            new MockHttpClient(new MockResponse('image', ['response_headers' => ['content-type: image/jpeg']])),
             new MockHttpClient($responseFactory, 'https://primary.example/api/v1/'),
             new MockHttpClient($responseFactory, 'https://secondary.example/api/v1/'),
             $this->createMock(RouterInterface::class),
@@ -32,12 +76,5 @@ class NotificationPublisherTest extends TestCase
             'secondary-token',
             true,
         );
-
-        $publisher->publishMastodonLiveAnnouncement('No Agenda 1889 Live', 'https://example.com/live');
-
-        $this->assertSame([
-            ['POST', 'https://primary.example/api/v1/statuses', 'status=No+Agenda+1889+Live+https%3A%2F%2Fexample.com%2Flive'],
-            ['POST', 'https://secondary.example/api/v1/statuses', 'status=No+Agenda+1889+Live+https%3A%2F%2Fexample.com%2Flive'],
-        ], $requests);
     }
 }


### PR DESCRIPTION
## Summary

Attach RSS album art to both live and newly published episode announcements on both Mastodon accounts.

## Changes

- read `itunes:image` from RSS Live Items
- reuse each episode's RSS `coverUri`
- download the image once and upload it separately to each Mastodon instance
- include accessible image description text
- publish the text status without art when download/upload fails or `write:media` is unavailable

## Testing

- `vendor/bin/phpunit tests/Crawling`
- `php bin/console lint:container`
- `php bin/console lint:yaml --parse-tags config`
- `git diff --check`
- confirmed the current RSS episode image returns JPEG content

## Merge Notes

Both access tokens should have `write:media` in addition to `write:statuses`. Missing media scope does not block status publication.
