### PR TITLE
fix: use media_ids[] form for Mastodon status posts

### DIFF
--- a/src/Crawling/NotificationPublisher.php
+++ b/src/Crawling/NotificationPublisher.php
@@ -128,7 +128,7 @@ class NotificationPublisher
                 $body = ['status' => $status];
 
                 if ($mediaId) {
-                    $body['media_ids'] = [$mediaId];
+                    $body['media_ids[]'] = $mediaId;
                 }
 
                 $response = $client->request('POST', 'statuses', [

--- a/tests/Crawling/NotificationPublisherTest.php
+++ b/tests/Crawling/NotificationPublisherTest.php
@@ -25,9 +25,9 @@ class NotificationPublisherTest extends TestCase
 
         $this->assertSame([
             ['POST', 'https://primary.example/api/v1/media'],
-            ['POST', 'https://primary.example/api/v1/statuses', 'status=No+Agenda+1889+Live+https%3A%2F%2Fexample.com%2Flive&media_ids%5B0%5D=primary-media'],
+            ['POST', 'https://primary.example/api/v1/statuses', 'status=No+Agenda+1889+Live+https%3A%2F%2Fexample.com%2Flive&media_ids%5B%5D=primary-media'],
             ['POST', 'https://secondary.example/api/v1/media'],
-            ['POST', 'https://secondary.example/api/v1/statuses', 'status=No+Agenda+1889+Live+https%3A%2F%2Fexample.com%2Flive&media_ids%5B0%5D=secondary-media'],
+            ['POST', 'https://secondary.example/api/v1/statuses', 'status=No+Agenda+1889+Live+https%3A%2F%2Fexample.com%2Flive&media_ids%5B%5D=secondary-media'],
         ], $requests);
     }
 


### PR DESCRIPTION
**Root cause** (gevonden via live-repro): `http_build_query(['media_ids' => [$id]])` encodeert als `media_ids[0]=...`, wat Mastodon stilletjes negeert (HTTP 200, maar geen attachment). De album-art werd dus wél geüpload maar nooit aan de post gekoppeld.

**Fix:** `media_ids[]=`-vorm gebruiken.

**Bewijs:** twee live testposts op podcastindex.social — `media_ids[0]` → geen media, `media_ids[]` → art gekoppeld.