### PR TITLE
fix(deps): update js-yaml to 3.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1970,9 +1970,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
## Summary
- Updates transitive development dependency `js-yaml` from 3.15.0 to 3.15.1.
- Fixes Dependabot alert #210.

## Verification
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm test -- --runInBand`
- `npm audit --omit=dev --audit-level=high`