### PR TITLE
fix(deps): update brace-expansion to 5.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5290,9 +5290,9 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "webpack-cli": "^7.0.0"
     },
     "overrides": {
-        "brace-expansion": "5.0.8"
+        "brace-expansion": "5.0.9"
     },
     "scripts": {
         "build": "encore dev",


### PR DESCRIPTION
## Summary
- Updates `brace-expansion` override from 5.0.8 to 5.0.9.
- Resolves `npm audit` findings for `brace-expansion` and its dependent `minimatch`.

## Verification
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm audit --audit-level=high`
- `npm test -- --runInBand`
- `npm run production`