### PR TITLE
ci: restrict test workflow token permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,9 @@ name: Run Tests
 
 on: push
 
+permissions:
+  contents: read
+
 env:
   APP_ENV: test
   APP_STORAGE_PATH: "${{ github.workspace }}/tests/fixtures"


### PR DESCRIPTION
Adds the minimum `contents: read` permission required by checkout. Resolves CodeQL alert #1.