### PR TITLE
fix: update EasyAdmin to 4.29.16

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1740,16 +1740,16 @@
         },
         {
             "name": "easycorp/easyadmin-bundle",
-            "version": "v4.29.14",
+            "version": "v4.29.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/EasyCorp/EasyAdminBundle.git",
-                "reference": "e6a58c24d082986d549ee9d9de0a97d69e4be7b7"
+                "reference": "bd7e837db9392d46b1d13a4048cd1df6f69798e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/EasyCorp/EasyAdminBundle/zipball/e6a58c24d082986d549ee9d9de0a97d69e4be7b7",
-                "reference": "e6a58c24d082986d549ee9d9de0a97d69e4be7b7",
+                "url": "https://api.github.com/repos/EasyCorp/EasyAdminBundle/zipball/bd7e837db9392d46b1d13a4048cd1df6f69798e4",
+                "reference": "bd7e837db9392d46b1d13a4048cd1df6f69798e4",
                 "shasum": ""
             },
             "require": {
@@ -1833,7 +1833,7 @@
             ],
             "support": {
                 "issues": "https://github.com/EasyCorp/EasyAdminBundle/issues",
-                "source": "https://github.com/EasyCorp/EasyAdminBundle/tree/v4.29.14"
+                "source": "https://github.com/EasyCorp/EasyAdminBundle/tree/v4.29.16"
             },
             "funding": [
                 {
@@ -1841,7 +1841,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-12T17:09:34+00:00"
+            "time": "2026-08-11T06:24:50+00:00"
         },
         {
             "name": "egulias/email-validator",


### PR DESCRIPTION
Replaces #111 with the smallest compatible lockfile update for GHSA-g2fm-8hr4-j82h.\n\nThe Dependabot lockfile updated unrelated Symfony dependencies into incompatible major versions, which broke the PHP install and Docker build. This update changes only `easycorp/easyadmin-bundle` from 4.29.14 to 4.29.16.\n\nVerified: `npm test` (336 tests), `podman build --target app`, and `git diff --check`.